### PR TITLE
Add animated flag on checkForPartialScroll

### DIFF
--- a/AMScrollingNavbar/AMScrollingNavbarController.h
+++ b/AMScrollingNavbar/AMScrollingNavbarController.h
@@ -119,7 +119,7 @@
  */
 - (void)hideNavbarAnimated:(BOOL)animated;
 
-- (void)restoreState;
+- (void)restoreStateAnimated:(BOOL)animated;
 
 /** Remove the scrollview tracking
  *

--- a/AMScrollingNavbar/AMScrollingNavbarController.m
+++ b/AMScrollingNavbar/AMScrollingNavbarController.m
@@ -172,12 +172,12 @@ static const NSInteger kAMNavBarOverlayTag = 23420;
 }
 
 - (void)didBecomeActive:(id)sender {
-    [self restoreState];
+    [self restoreStateAnimated:YES];
 }
 
-- (void)restoreState {
+- (void)restoreStateAnimated:(BOOL)animated {
     if (self.navigationController) {
-        [self checkForPartialScroll];
+        [self checkForPartialScrollAnimated:animated];
     }
 }
 
@@ -291,7 +291,7 @@ static const NSInteger kAMNavBarOverlayTag = 23420;
     
     if ([gesture state] == UIGestureRecognizerStateEnded || [gesture state] == UIGestureRecognizerStateCancelled) {
         // Reset the nav bar if the scroll is partial
-        [self checkForPartialScroll];
+        [self checkForPartialScrollAnimated:YES];
         [self checkForHeaderPartialScroll];
         self.lastContentOffset = 0;
     }
@@ -441,7 +441,7 @@ static const NSInteger kAMNavBarOverlayTag = 23420;
     } completion:nil];
 }
 
-- (void)checkForPartialScroll {
+- (void)checkForPartialScrollAnimated:(BOOL)animated {
     CGFloat pos = self.navigationController.navigationBar.frame.origin.y;
     __block CGRect frame = self.navigationController.navigationBar.frame;
     
@@ -456,8 +456,13 @@ static const NSInteger kAMNavBarOverlayTag = 23420;
             self.expanded = YES;
             self.collapsed = NO;
             
-            [self updateSizingWithDelta:delta];
+            if (animated) {
+                [self updateSizingWithDelta:delta];
+            }
         } completion:nil];
+        if (!animated) {
+            [self updateSizingWithDelta:delta];
+        }
     } else {
         // And back up
         CGFloat delta = frame.origin.y + self.deltaLimit;
@@ -469,8 +474,14 @@ static const NSInteger kAMNavBarOverlayTag = 23420;
             self.expanded = NO;
             self.collapsed = YES;
             
-            [self updateSizingWithDelta:delta];
+            if (animated) {
+                [self updateSizingWithDelta:delta];
+            }
         } completion:nil];
+        if (!animated) {
+            [self updateSizingWithDelta:delta];
+        }
+        
     }
 }
 


### PR DESCRIPTION
Assume navigation controller contains two view controllers A and B, with B shown on top. A uses `AMScrollingNavBar`, i.e. calls `restoreState` in its `viewWillAppear`. B shows/hides its navigation bar with `animated:YES` in its `viewWillAppear` and `viewWillDisappear`.

When B's interactive pop gesture begins and gets cancelled, animation in `AMScrollingNavBar`'s `checkForPartialScroll`, specifically `[self.overlay setAlpha:1 - alpha];` in `updateNavbarAlpha`, conflicts with the navigation transition animation, and results in a 64px gap on top of the screen.

This PR fixes this issue by adding `animated` flag in `checkForPartialScroll` and `restoreState`, so A in the above example can call `restoreState` with no animation.
