### PR TITLE
Hide overlay when its alpha is zero

### DIFF
--- a/AMScrollingNavbar/AMScrollingNavbarController.m
+++ b/AMScrollingNavbar/AMScrollingNavbarController.m
@@ -150,6 +150,7 @@ static const NSInteger kAMNavBarOverlayTag = 23420;
     [self.overlay setAutoresizingMask:UIViewAutoresizingFlexibleWidth];
     [self.navigationController.navigationBar addSubview:self.overlay];
     self.overlay.alpha = self.expanded ? 0 : 1;
+    self.overlay.hidden = self.overlay.alpha == 0;
     
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(didBecomeActive:)
@@ -519,6 +520,7 @@ static const NSInteger kAMNavBarOverlayTag = 23420;
     // Change the alpha channel of every item on the navbr. The overlay will appear, while the other objects will disappear, and vice versa
     float alpha = (frame.origin.y + self.deltaLimit) / frame.size.height;
     [self.overlay setAlpha:1 - alpha];
+    self.overlay.hidden = self.overlay.alpha == 0;
     [self.navigationItem.leftBarButtonItems enumerateObjectsUsingBlock:^(UIBarButtonItem *obj, NSUInteger idx, BOOL *stop) {
         obj.customView.alpha = alpha;
     }];


### PR DESCRIPTION
There is a method call `[UINavigationBar _fadeViewsIn:]` in iOS SDK which is triggered when we call `[UINavigationController setNavigationBarHidden:animated:]`. This sets `alpha` value of the overlay back to 1 (even when it is supposed to stay at 0) blocking navigation titles.

So we use `hidden` property to completely hide the overlay when its `alpha` is zero.
